### PR TITLE
Fix filename output for riffusion extension's batch output

### DIFF
--- a/file2img.py
+++ b/file2img.py
@@ -228,7 +228,7 @@ input_filename_only = Path(args.input).stem
 print("SAVING SPECTOGRAM IMAGES")
 for i, image in enumerate(spectrogram_images):
     # Generate output filename for this image
-    output_filename = f"{args.output}/{input_filename_only}_{i}.png"
+    output_filename = f"{args.output}/{input_filename_only}_{i:05d}.png"
     image.save(output_filename)
 
 print("FINISHED")


### PR DESCRIPTION
hi, thanks for the tool!
this fixes a naming problem when using the files with the riffusion extension's batch output mode, where .wav files are read and joined

0 > 1 > 11 > 12 ... 

now

00000 > 00001 > 00002