### PR TITLE
Normalize before returning image from spectrogram

### DIFF
--- a/file2img.py
+++ b/file2img.py
@@ -10,6 +10,7 @@ import argparse
 from typing import List
 import os
 from pathlib import Path
+import cv2
 
 parser = argparse.ArgumentParser()
 parser.add_argument("-i", "--input", type=str, help="Input file to process, anything that FFMPEG supports, but wav and mp3 are recommended")

--- a/file2img.py
+++ b/file2img.py
@@ -125,6 +125,7 @@ def image_from_spectrogram(
     data = data / (max_volume / 255)
     data = 255 - data
     data = data[::-1]
+    data = cv2.normalize(data, None, 0, 255, cv2.NORM_MINMAX)
     image = Image.fromarray(data.astype(np.uint8))
     return image
 


### PR DESCRIPTION
Without normalizing you have to play around with the settings more to get a good level or you can end up with it being very low, or so high it clips.

There may be a better way to go about this, but this was a quick way I found to make my data better.

Here are samples of with and without this normalization change. 255 volume. Power for image 0.1, 0.2, 0.3, 0.4, 0.5, & 1.0.
![pr_compare](https://github.com/chavinlo/riffusion-manipulation/assets/16216325/4e586c13-fd0a-4097-b802-1a62200d12cd)
